### PR TITLE
Implement ABACUS work-function tasks 1101 and 1102

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Configures pseudopotential paths, orbital directories, ABACUS binary location, a
 | 1001 | 1D Planar Avg Charge | Planar-averaged charge density |
 | 1002 | Export Cube/XSF | Export for VESTA visualization |
 | 1003 | Diff. Charge Density | Δρ = ρ_AB − ρ_A − ρ_B |
-| 1101 | Work Function | ⏳ 待开发 (coming soon) — Φ = V_vacuum − E_Fermi |
-| 1102 | Macroscopic Avg | ⏳ 待开发 (coming soon) — Double-averaged potential |
+| 1101 | Work Function | Work function from `E_vacuum.out` and final SCF `E_Fermi` |
+| 1102 | Macroscopic Avg | Periodic double-averaged potential and work function |
 | 1201 | Elastic Constants | Parse elastic tensor, VRH moduli |
 | 1202 | EOS Fitting | Birch-Murnaghan equation of state |
 | 1301 | Mulliken Analysis | Mulliken population |

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Configures pseudopotential paths, orbital directories, ABACUS binary location, a
 | 1001 | 1D Planar Avg Charge | Planar-averaged charge density |
 | 1002 | Export Cube/XSF | Export for VESTA visualization |
 | 1003 | Diff. Charge Density | Δρ = ρ_AB − ρ_A − ρ_B |
-| 1101 | Work Function | Work function from `E_vacuum.out` and final SCF `E_Fermi` |
-| 1102 | Macroscopic Avg | Periodic double-averaged potential and work function |
+| 1101 | Work Function | Vacuum level from raw `ElecStaticPot.cube` and final SCF `E_Fermi` |
+| 1102 | Macroscopic Avg | Periodic double-averaged raw cube potential and work function |
 | 1201 | Elastic Constants | Parse elastic tensor, VRH moduli |
 | 1202 | EOS Fitting | Birch-Murnaghan equation of state |
 | 1301 | Mulliken Analysis | Mulliken population |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -753,6 +753,19 @@ abacuscopilot -task 1102   # 周期双窗口宏观平均法功函数
 # --period 可指定平滑周期（Å）；默认使用 c 轴长度的四分之一
 ```
 
+### 真实 ABACUS 输出验证
+
+仓库提供了一个不携带大体积计算结果的可选端到端测试。准备一个已经完成的
+ABACUS SCF 目录（需要 `OUT.ABACUS/ElecStaticPot.cube` 和
+`OUT.ABACUS/running_scf.log`），然后设置目录并运行：
+
+```bash
+set ABACUS_WORKFUNC_CASE=D:\path\to\completed_scf
+python -m pytest -q tests/test_workfunc_real_case.py
+```
+
+该测试会同时检查原始 cube 真空能级路径和 1102 周期宏观平均路径；未设置环境变量时自动跳过。
+
 ---
 
 ## 16. 力学性质

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -734,15 +734,16 @@ abacuscopilot -task 1003   # 差分电荷密度
 
 ## 15. 功函数
 
-任务号 1101–1102 已开放。两项任务读取 ABACUS `ElecStaticPot.cube`；若目录中存在
-zstar 生成的 `E_vacuum.out`，直接使用其中的真空能级，并从 `running_scf.log`
-读取最终 `E_Fermi`，按 `Φ = V_vacuum − E_Fermi` 计算功函数。
+任务号 1101–1102 已开放。两项任务直接读取 ABACUS 原始
+`ElecStaticPot.cube`：从 cube 中的原子坐标识别最大的周期性无原子真空间隙，
+在排除表面邻近区域后得到 `V_vacuum`；再从 `running_scf.log` 读取最终
+`E_Fermi`，按 `Φ = V_vacuum − E_Fermi` 计算功函数。整个流程不依赖 zstar。
 
 ### 1101 — Work Function
 
 ```bash
 abacuscopilot -task 1101   # 功函数计算
-# 也可显式指定：--file ElecStaticPot.cube --vacuum-file E_vacuum.out --log OUT.ABACUS/running_scf.log
+# 也可显式指定：--file ElecStaticPot.cube --log OUT.ABACUS/running_scf.log
 ```
 
 ### 1102 — Macroscopic Avg

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -734,20 +734,22 @@ abacuscopilot -task 1003   # 差分电荷密度
 
 ## 15. 功函数
 
-> ⏳ **待开发 (coming soon)**：任务 1101–1102 功能可用性尚未验证，当前已隐藏（交互菜单进入 `11) Work Function Analysis` 会显示"此模块待开发"）。验证通过后重新开放。
-
-任务号 1101–1102（预留）。
+任务号 1101–1102 已开放。两项任务读取 ABACUS `ElecStaticPot.cube`；若目录中存在
+zstar 生成的 `E_vacuum.out`，直接使用其中的真空能级，并从 `running_scf.log`
+读取最终 `E_Fermi`，按 `Φ = V_vacuum − E_Fermi` 计算功函数。
 
 ### 1101 — Work Function
 
 ```bash
-abacuscopilot -task 1101   # 功函数计算（待开发）
+abacuscopilot -task 1101   # 功函数计算
+# 也可显式指定：--file ElecStaticPot.cube --vacuum-file E_vacuum.out --log OUT.ABACUS/running_scf.log
 ```
 
 ### 1102 — Macroscopic Avg
 
 ```bash
-abacuscopilot -task 1102   # 宏观平均法功函数（待开发）
+abacuscopilot -task 1102   # 周期双窗口宏观平均法功函数
+# --period 可指定平滑周期（Å）；默认使用 c 轴长度的四分之一
 ```
 
 ---

--- a/abacuscopilot/postprocessing/workfunc_tasks.py
+++ b/abacuscopilot/postprocessing/workfunc_tasks.py
@@ -1,7 +1,6 @@
 """Work function analysis tasks for ABACUS output.
 
-Task IDs 1101-1102 (currently HIDDEN — functionality not yet verified;
-tasks 1101/1102 are disabled until validated, see the @task comments below).
+Task IDs 1101-1102.
 
 Reads electrostatic potential from OUT.ABACUS, computes 1D planar
 average along the vacuum direction, and extracts the work function.
@@ -15,31 +14,163 @@ Method:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 
 from abacuscopilot.console_utils import _get_console
+from abacuscopilot.core.constants import BOHR_TO_ANGSTROM, RY_TO_EV
+from abacuscopilot.tasks import task
 
 # =============================================================================
 # Potential file finder
 # =============================================================================
 
 
-def _find_potential_file() -> Path | None:
-    """Find electrostatic potential file in the working directory."""
+def _find_potential_file(root: str | Path = ".") -> Path | None:
+    """Find the newest electrostatic-potential file below *root*.
+
+    ABACUS writes ``ElecStaticPot.cube`` below ``OUT.*``.  A few older
+    workflows use ``POT.cube`` or VASP's ``LOCPOT`` name, so those aliases are
+    kept for compatibility with the original task.
+    """
+    root = Path(root)
     candidates = (
-        list(Path().glob("ElecStaticPot*.cube")) +
-        list(Path().glob("LOCPOT*")) +
-        list(Path().glob("POT.cube")) +
-        list(Path().glob("OUT.*/ElecStaticPot*.cube")) +
-        list(Path().glob("OUT.*/LOCPOT*")) +
-        list(Path().glob("OUT.*/POT.cube"))
+        list(root.glob("ElecStaticPot*.cube")) +
+        list(root.glob("LOCPOT*")) +
+        list(root.glob("POT.cube")) +
+        list(root.glob("OUT.*/ElecStaticPot*.cube")) +
+        list(root.glob("OUT.*/LOCPOT*")) +
+        list(root.glob("OUT.*/POT.cube"))
     )
+    candidates = [path for path in candidates if path.is_file()]
     if not candidates:
         return None
     return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _find_vacuum_file(
+    root: str | Path = ".",
+    potential_path: str | Path | None = None,
+    explicit: str | Path | None = None,
+) -> Path | None:
+    """Find zstar/ABACUS's scalar vacuum-level report.
+
+    ``E_vacuum.out`` is preferred over the two-sided diagnostic because it is
+    already a single vacuum reference suitable for ``Phi = V_vacuum - E_F``.
+    """
+    if explicit:
+        path = Path(explicit)
+        return path if path.is_file() else None
+
+    root = Path(root)
+    search_roots = []
+    if potential_path is not None:
+        potential = Path(potential_path)
+        search_roots.extend([potential.parent, potential.parent.parent])
+    search_roots.extend([root, *[p for p in root.glob("OUT.*") if p.is_dir()]])
+
+    seen: set[Path] = set()
+    for directory in search_roots:
+        directory = directory.resolve()
+        if directory in seen:
+            continue
+        seen.add(directory)
+        for name in ("E_vacuum.out", "E_vacuum_sides.out"):
+            path = directory / name
+            if path.is_file():
+                return path
+    return None
+
+
+def read_vacuum_level(filepath: str | Path) -> float | None:
+    """Read a vacuum level in eV from ``E_vacuum.out``-style text.
+
+    zstar writes ``E_VACUUM (eV) = ...``.  The parser also accepts a
+    two-sided report and returns the mean of its lower/upper plateau values.
+    """
+    path = Path(filepath)
+    if not path.is_file():
+        return None
+
+    number = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
+    direct = re.compile(
+        rf"(?:E|V)[_ ]?VACUUM(?:\s*\([^)]*\))?\s*=\s*({number})", re.I
+    )
+    side = re.compile(
+        rf"(?:LOWER|UPPER)[_ ]?VACUUM(?:\s*\([^)]*\))?\s*=\s*({number})", re.I
+    )
+
+    side_values = []
+    for line in path.read_text(errors="ignore").splitlines():
+        match = direct.search(line)
+        if match:
+            return float(match.group(1))
+        match = side.search(line)
+        if match:
+            side_values.append(float(match.group(1)))
+    if side_values:
+        return float(np.mean(side_values))
+    return None
+
+
+def _find_scf_log(
+    root: str | Path = ".",
+    potential_path: str | Path | None = None,
+    explicit: str | Path | None = None,
+) -> Path | None:
+    """Find the newest SCF log associated with a potential output."""
+    if explicit:
+        path = Path(explicit)
+        return path if path.is_file() else None
+
+    root = Path(root)
+    search_roots = []
+    if potential_path is not None:
+        potential = Path(potential_path)
+        search_roots.extend([potential.parent, potential.parent.parent])
+    search_roots.append(root)
+
+    candidates = []
+    for directory in search_roots:
+        candidates.extend(directory.glob("running_*.log"))
+        candidates.extend(directory.glob("OUT.*/running_*.log"))
+    candidates = [path for path in candidates if path.is_file()]
+    return max(candidates, key=lambda p: p.stat().st_mtime) if candidates else None
+
+
+def read_fermi_energy(filepath: str | Path) -> float | None:
+    """Extract the final ABACUS Fermi energy in eV from an SCF log.
+
+    ABACUS commonly prints ``E_Fermi <Ry> <eV>``; newer builds may spell this
+    as ``Fermi energy (eV) = ...``.  The last matching line is used so relax
+    and MD logs resolve to the final electronic step.
+    """
+    path = Path(filepath)
+    if not path.is_file():
+        return None
+
+    number = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
+    ev_value = re.compile(rf"({number})\s*eV\b", re.I)
+    fermi_line = re.compile(r"(?:E_Fermi|E-fermi|EFERMI|Fermi\s+(?:energy|level))", re.I)
+
+    for line in reversed(path.read_text(errors="ignore").splitlines()):
+        if not fermi_line.search(line):
+            continue
+        values = ev_value.findall(line)
+        if values:
+            return float(values[-1])
+
+        # Standard ABACUS text has two bare numbers: Ry first, eV second.
+        tail = line[fermi_line.search(line).end():]
+        values = re.findall(number, tail)
+        if len(values) >= 2:
+            return float(values[-1])
+        if values:
+            return float(values[-1])
+    return None
 
 
 # =============================================================================
@@ -56,61 +187,54 @@ def read_potential_cube(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, n
     if not filepath.exists():
         return None
 
-    with open(filepath) as f:
-        lines = [l.strip() for l in f if l.strip() if not l.startswith("#")]
-
+    lines = filepath.read_text(errors="ignore").splitlines()
     if len(lines) < 6:
         return None
 
-    # Skip 2 comment lines
-    data_start = 2
+    # Cube files have two comments followed by a geometry block.  Searching
+    # for that block also handles ABACUS files with an optional extra comment.
+    geometry = None
+    for index in range(min(40, len(lines) - 3)):
+        parts = lines[index].split()
+        if len(parts) != 4:
+            continue
+        try:
+            natom = abs(int(parts[0]))
+            origin = np.array([float(x) for x in parts[1:4]])
+            dimensions = []
+            cell = np.zeros((3, 3))
+            for axis in range(3):
+                row = lines[index + axis + 1].split()
+                if len(row) != 4:
+                    raise ValueError
+                n = abs(int(row[0]))
+                dimensions.append(n)
+                cell[axis] = np.array([float(x) for x in row[1:4]]) * n
+            geometry = (index, natom, origin, dimensions, cell)
+            break
+        except (TypeError, ValueError, IndexError):
+            continue
 
-    # Origin line: natom x0 y0 z0
-    parts = lines[data_start].split()
-    natom = int(parts[0])
-    origin = np.array([float(parts[1]), float(parts[2]), float(parts[3])])
-    data_start += 1
+    if geometry is None:
+        return None
 
-    # Grid dimensions: nx dx dy dz
-    parts = lines[data_start].split()
-    nx = int(parts[0])
-    data_start += 1
-
-    cell = np.zeros((3, 3))
-    for i in range(3):
-        parts = lines[data_start + i].split()
-        n = int(parts[0])
-        cell[i] = np.array([float(p) * n for p in parts[1:4]])
-    data_start += 3
-
-    # Skip atom positions
-    data_start += natom
-
+    geometry_index, natom, origin, dimensions, cell = geometry
+    data_start = geometry_index + 4 + natom
     if data_start >= len(lines):
         return None
 
-    # Read ny, nz
-    ny = nx
-    nz = nx
-    if data_start < len(lines):
-        parts = lines[data_start].split()
-        if len(parts) == 1:
-            ny = int(parts[0])
-            data_start += 1
-    if data_start < len(lines):
-        parts = lines[data_start].split()
-        if len(parts) == 1:
-            nz = int(parts[0])
-            data_start += 1
-
-    # Read volumetric data
     raw = []
     for line in lines[data_start:]:
         raw.extend(float(x) for x in line.split())
 
+    nx, ny, nz = dimensions
     expected = nx * ny * nz
-    data = np.array(raw[:expected]).reshape(nz, ny, nx)
+    if len(raw) < expected:
+        return None
 
+    # Gaussian/ABACUS cube data are ordered with the last grid axis varying
+    # fastest.  Keeping (x, y, z) here makes the z planar average unambiguous.
+    data = np.asarray(raw[:expected], dtype=float).reshape(nx, ny, nz)
     return data, cell, origin
 
 
@@ -139,8 +263,18 @@ def extract_work_function(
     Returns:
         Dict with 'vacuum_level', 'work_function', 'e_fermi', 'z_vacuum'.
     """
+    potential_1d = np.asarray(potential_1d, dtype=float)
+    z_axis = np.asarray(z_axis, dtype=float)
+    if potential_1d.ndim != 1 or z_axis.ndim != 1 or len(potential_1d) != len(z_axis):
+        raise ValueError("potential_1d and z_axis must be one-dimensional arrays of equal length")
+    if len(potential_1d) == 0:
+        raise ValueError("potential_1d cannot be empty")
+    if not 0.0 < vacuum_fraction <= 1.0:
+        raise ValueError("vacuum_fraction must be between 0 and 1")
+
     npts = len(potential_1d)
     vac_start = int(npts * (1 - vacuum_fraction))
+    vac_start = min(max(vac_start, 0), npts - 1)
 
     # Find vacuum level: average over the vacuum region
     vac_region = potential_1d[vac_start:]
@@ -157,240 +291,288 @@ def extract_work_function(
     }
 
 
+def macroscopic_average(potential_1d: np.ndarray, window_points: int) -> np.ndarray:
+    """Apply the periodic double-window macroscopic average used by 1102.
+
+    Periodic wrapping avoids the artificial zero-padding edge distortion of
+    ``np.convolve(..., mode='same')`` at the cell boundary.
+    """
+    values = np.asarray(potential_1d, dtype=float)
+    if values.ndim != 1 or values.size == 0:
+        raise ValueError("potential_1d must be a non-empty one-dimensional array")
+    window = max(1, min(int(window_points), values.size))
+    if window == 1:
+        return values.copy()
+
+    def running_average(arr: np.ndarray) -> np.ndarray:
+        extended = np.concatenate([arr, arr[: window - 1]])
+        cumulative = np.concatenate([[0.0], np.cumsum(extended)])
+        averaged = (cumulative[window:] - cumulative[:-window]) / window
+        # The forward window is shifted so it is centered at each grid point.
+        return np.roll(averaged[: arr.size], window // 2)
+
+    return running_average(running_average(values))
+
+
+def _potential_to_ev(values: np.ndarray, path: Path) -> np.ndarray:
+    """Convert ABACUS cube values to eV, preserving LOCPOT compatibility."""
+    # ABACUS ElecStaticPot.cube is in Ry.  LOCPOT is conventionally already eV.
+    return np.asarray(values, dtype=float) if path.name.upper().startswith("LOCPOT") else values * RY_TO_EV
+
+
 # =============================================================================
 # Task 1101: 1D planar average potential + work function
-#
-# HIDDEN (2026-08-31): functionality not yet verified — availability pending.
-# Re-enable by un-commenting the @task decorator below.
 # =============================================================================
 
 
-# @task(1101, category="Work Function", name="Work Function",
-#       description="Compute 1D planar-averaged electrostatic potential and extract work function",
-#       cli_args=[
-#           {"name": "--file", "type": str, "default": None, "help": "Path to electrostatic potential cube file"},
-#       ])
-def task_work_function(args: list[str] | None = None, interactive: bool = True,
-                       parsed_args=None) -> None:
-    """Compute work function from electrostatic potential.
+def _pick_path(parsed_args, args: list[str] | None, name: str, keywords: tuple[str, ...]) -> Path | None:
+    """Resolve an explicit CLI path, then a positional path, if present."""
+    explicit = getattr(parsed_args, name, None) if parsed_args is not None else None
+    if explicit:
+        return Path(explicit)
+    for arg in args or []:
+        path = Path(arg)
+        if path.is_file() and any(keyword in path.name.upper() for keyword in keywords):
+            return path
+    return None
 
-    Reads the electrostatic potential cube file, computes a 1D planar
-    average along z, and extracts the vacuum level to determine the
-    work function: Φ = V_vacuum − E_Fermi.
+
+def _read_profile(path: Path) -> tuple[np.ndarray, np.ndarray, float, tuple[int, int, int]] | None:
+    """Read a cube and return ``(z, planar_potential, dz, shape)`` in eV/Å."""
+    result = read_potential_cube(path)
+    if result is None:
+        return None
+    potential, cell, origin = result
+    nx, ny, nz = potential.shape
+    cell_ang = cell * BOHR_TO_ANGSTROM
+    c_length = float(np.linalg.norm(cell_ang[2]))
+    z = (origin[2] + np.linspace(0.0, cell[2, 2], nz, endpoint=False)) * BOHR_TO_ANGSTROM
+    dz = c_length / nz
+    profile = _potential_to_ev(np.mean(potential, axis=(0, 1)), path)
+    return z, profile, dz, (nx, ny, nz)
+
+
+def _resolve_fermi(
+    root: Path,
+    potential_path: Path | None,
+    parsed_args,
+    args: list[str] | None,
+) -> tuple[float | None, Path | None]:
+    explicit = getattr(parsed_args, "fermi", None) if parsed_args is not None else None
+    if explicit is not None:
+        return float(explicit), None
+    log_path = _pick_path(parsed_args, args, "log", ("LOG", "RUNNING"))
+    log_path = _find_scf_log(root, potential_path, log_path)
+    return (read_fermi_energy(log_path), log_path) if log_path else (None, None)
+
+
+def _write_work_function_result(output_dir: Path, result: dict[str, Any]) -> None:
+    import json
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "work_function.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def _plot_work_function(
+    output_path: Path,
+    z_ang: np.ndarray,
+    planar: np.ndarray,
+    e_fermi: float,
+    vacuum_level: float,
+    title: str,
+    macro: np.ndarray | None = None,
+) -> None:
+    import matplotlib.pyplot as plt
+
+    from abacuscopilot.plotting.style import load_style_from_config
+    load_style_from_config()
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.plot(z_ang, planar, color="#1f77b4", linewidth=0.9, alpha=0.65, label="Planar average")
+    if macro is not None:
+        ax.plot(z_ang, macro, color="#d62728", linewidth=1.5, label="Macroscopic average")
+    ax.axhline(y=vacuum_level, color="red", linestyle="--", linewidth=0.8,
+               label=f"V_vac = {vacuum_level:.3f} eV")
+    ax.axhline(y=e_fermi, color="blue", linestyle="--", linewidth=0.8,
+               label=f"E_F = {e_fermi:.3f} eV")
+    ax.set_xlabel("z (Å)")
+    ax.set_ylabel("V (eV)")
+    ax.set_title(title)
+    ax.legend(loc="upper right")
+    ax.set_xlim(z_ang.min(), z_ang.max())
+    fig.savefig(output_path)
+    plt.close(fig)
+
+
+@task(
+    1101,
+    category="Work Function",
+    name="Work Function",
+    description="Compute work function from V_vacuum and the final SCF E_Fermi",
+    cli_args=[
+        {"name": "--file", "type": str, "default": None, "help": "Path to electrostatic potential cube file"},
+        {"name": "--vacuum-file", "type": str, "default": None, "help": "Path to E_vacuum.out"},
+        {"name": "--log", "type": str, "default": None, "help": "Path to SCF running log"},
+        {"name": "--fermi", "type": float, "default": None, "help": "Override E_Fermi (eV)"},
+        {"name": "--no-plot", "action": "store_true", "help": "Write data without a PNG plot"},
+    ],
+)
+def task_work_function(
+    args: list[str] | None = None,
+    interactive: bool = True,
+    parsed_args=None,
+    output_dir: str = ".",
+) -> dict[str, Any] | None:
+    """Compute ``Phi = V_vacuum - E_Fermi`` for an ABACUS slab.
+
+    When zstar has already produced ``E_vacuum.out``, that scalar is used
+    directly.  The cube is only needed for the optional planar profile/plot;
+    if the report is absent, the final vacuum fraction is retained as a
+    clearly marked fallback estimate.
     """
     console = _get_console()
+    root = Path.cwd()
+    output = Path(output_dir)
+    pot_path = _pick_path(parsed_args, args, "file", ("POT", "ELEC", "LOCPOT")) or _find_potential_file(root)
+    vacuum_path = _find_vacuum_file(
+        root, pot_path, getattr(parsed_args, "vacuum_file", None) if parsed_args else None
+    )
+    fermi, log_path = _resolve_fermi(root, pot_path, parsed_args, args)
 
     console.print()
     console.print("[bold cyan]=== Work Function Analysis ===[/bold cyan]")
     console.print()
+    if fermi is None:
+        console.print("[red]Could not find E_Fermi in an SCF log.[/red]")
+        console.print("[dim]Pass --log running_scf.log or --fermi <eV>.[/dim]")
+        return None
+    if log_path:
+        console.print(f"  [dim]SCF log: {log_path}[/dim]")
+    console.print(f"  [bold]E_Fermi:[/bold] {fermi:.6f} eV")
 
-    # Find potential file
-    pot_path = None
-    if parsed_args and parsed_args.file:
-        pot_path = Path(parsed_args.file)
-    if pot_path is None and args:
-        for arg in args:
-            if "POT" in arg.upper() or "ELEC" in arg.upper():
-                p = Path(arg)
-                if p.exists():
-                    pot_path = p
-                    break
-    if pot_path is None:
-        pot_path = _find_potential_file()
+    profile = _read_profile(pot_path) if pot_path else None
+    if pot_path:
+        console.print(f"  [dim]Potential file: {pot_path}[/dim]")
+    if profile:
+        z_ang, planar, _dz, shape = profile
+        console.print(f"  [bold]Grid:[/bold] {shape[0]} × {shape[1]} × {shape[2]}")
+    else:
+        z_ang = planar = None
 
-    if pot_path is None:
-        console.print("[red]No electrostatic potential file found.[/red]")
-        console.print("[dim]Run an ABACUS SCF calculation with out_pot=2.[/dim]")
-        console.print("[dim]Look for files like: ElecStaticPot.cube or POT.cube in OUT.ABACUS/[/dim]")
-        return
+    vacuum_level = read_vacuum_level(vacuum_path) if vacuum_path else None
+    if vacuum_level is not None:
+        source = str(vacuum_path)
+        wf = {"vacuum_level": vacuum_level, "work_function": vacuum_level - fermi,
+              "e_fermi": fermi, "vacuum_source": source}
+    elif profile:
+        fallback = extract_work_function(planar, z_ang, e_fermi=fermi, vacuum_fraction=0.3)
+        wf = {**fallback, "vacuum_source": "top 30% planar-average fallback"}
+        console.print("  [yellow]E_vacuum.out not found; using top 30% planar average.[/yellow]")
+    else:
+        console.print("[red]No readable potential cube or E_vacuum.out found.[/red]")
+        return None
 
-    console.print(f"  [dim]Potential file: {pot_path}[/dim]")
-
-    # Read potential
-    result = read_potential_cube(pot_path)
-    if result is None:
-        console.print("[red]Could not read potential cube file.[/red]")
-        return
-
-    potential_3d, cell, origin = result
-    nz, ny, nx = potential_3d.shape
-    console.print(f"  [bold]Grid:[/bold] {nx} × {ny} × {nz}")
-
-    # Convert cell from Bohr to Angstrom for display
-    from abacuscopilot.core.constants import BOHR_TO_ANGSTROM
-    cell_ang = cell * BOHR_TO_ANGSTROM
-    c_length = np.linalg.norm(cell_ang[2])
-    console.print(f"  [bold]Cell c-axis:[/bold] {c_length:.4f} Å")
-
-    # 1D planar average along z (axis=0 in z,y,x ordering)
-    avg_pot = np.mean(potential_3d, axis=(1, 2))  # average over x and y
-    z_coords = origin[2] + np.linspace(0, cell[2, 2], nz, endpoint=False)
-    z_ang = z_coords * BOHR_TO_ANGSTROM
-
-    # Get E_Fermi
-    e_fermi = 0.0
-    # Try reading from INPUT or output
-    try:
-        from abacuscopilot.io.input_file import read_input
-        params = read_input("INPUT")
-        # Look for scf_thr in extras (some versions store E_Fermi)
-    except Exception:
-        pass
-
-    # Try reading from running_scf.log for e_fermi
-    log_candidates = (list(Path().glob("running_*.log")) +
-                     list(Path().glob("OUT.*/running_scf.log")))
-    for log_path in log_candidates:
-        try:
-            content = log_path.read_text()
-            import re
-            m = re.search(r"(?:EFERMI|E-fermi|Fermi)\s*[=:]\s*([\d.-]+)", content, re.IGNORECASE)
-            if m:
-                e_fermi = float(m.group(1))
-                break
-        except Exception:
-            pass
-
-    console.print(f"  [bold]E_Fermi:[/bold] {e_fermi:.6f} eV" if e_fermi != 0.0 else "  [yellow]E_Fermi: 0.0 (not found, using 0)[/yellow]")
-
-    # Extract work function
-    wf = extract_work_function(avg_pot, z_ang, e_fermi=e_fermi, vacuum_fraction=0.3)
-
-    console.print()
     console.print(f"  [bold green]Vacuum Level:[/bold green] {wf['vacuum_level']:.4f} eV")
     console.print(f"  [bold green]Work Function (Φ):[/bold green] {wf['work_function']:.4f} eV")
-    console.print(f"  Vacuum region: z > {wf['z_vacuum_start']:.2f} Å")
+    if vacuum_path:
+        console.print(f"  [dim]Vacuum source: {vacuum_path}[/dim]")
 
-    # Plot
-    import matplotlib.pyplot as plt
-
-    from abacuscopilot.plotting.style import load_style_from_config
-    load_style_from_config()
-
-    fig, ax = plt.subplots(figsize=(8, 5))
-    ax.plot(z_ang, avg_pot, color="#1f77b4", linewidth=1.5)
-    ax.axhline(y=wf["vacuum_level"], color="red", linestyle="--", linewidth=0.8,
-               label=f"V_vac = {wf['vacuum_level']:.3f} eV")
-    ax.axhline(y=e_fermi, color="blue", linestyle="--", linewidth=0.8,
-               label=f"E_F = {e_fermi:.3f} eV")
-    ax.axvline(x=wf["z_vacuum_start"], color="gray", linestyle=":", linewidth=0.5,
-               label=f"Vacuum start ({wf['z_vacuum_start']:.1f} Å)")
-    ax.set_xlabel("z (Å)")
-    ax.set_ylabel("V (eV)")
-    ax.set_title(f"Planar-Averaged Potential — Work Function = {wf['work_function']:.3f} eV")
-    ax.legend(loc="upper right")
-    ax.set_xlim(z_ang.min(), z_ang.max())
-
-    # Save data
-    data_file = "planar_avg_potential.dat"
-    np.savetxt(data_file, np.column_stack([z_ang, avg_pot]),
-               fmt="%.8f", header="z_Angstrom  V_eV")
-    console.print(f"  [dim]Data saved to {data_file}[/dim]")
-
-    save_name = "work_function.png"
-    fig.savefig(save_name)
-    console.print(f"  [green]✓ Plot saved to {save_name}[/green]")
-    plt.close(fig)
-    console.print()
+    output.mkdir(parents=True, exist_ok=True)
+    if profile:
+        np.savetxt(output / "planar_avg_potential.dat", np.column_stack([z_ang, planar]),
+                   fmt="%.8f", header="z_Angstrom  V_eV")
+        if not getattr(parsed_args, "no_plot", False):
+            _plot_work_function(
+                output / "work_function.png", z_ang, planar, fermi, wf["vacuum_level"],
+                f"Planar-Averaged Potential — Work Function = {wf['work_function']:.3f} eV",
+            )
+    _write_work_function_result(output, wf)
+    console.print(f"  [dim]Results saved to {output / 'work_function.json'}[/dim]")
+    return wf
 
 
-# =============================================================================
-# Task 1102: Macroscopic average (double average for semiconductor slabs)
-#
-# HIDDEN (2026-08-31): functionality not yet verified — availability pending.
-# Re-enable by un-commenting the @task decorator below.
-# =============================================================================
-
-
-# @task(1102, category="Work Function", name="Macroscopic Avg",
-#       description="Compute macroscopic-averaged potential (double filter) for better vacuum level")
-def task_macro_avg_potential(args: list[str] | None = None, interactive: bool = True) -> None:
-    """Compute macroscopic-averaged electrostatic potential.
-
-    Uses a double-window averaging technique to remove atomic oscillations,
-    yielding a smoother potential profile for more accurate work function
-    extraction.
-    """
+@task(
+    1102,
+    category="Work Function",
+    name="Macroscopic Avg",
+    description="Compute a periodic double-averaged potential and work function",
+    cli_args=[
+        {"name": "--file", "type": str, "default": None, "help": "Path to electrostatic potential cube file"},
+        {"name": "--vacuum-file", "type": str, "default": None, "help": "Path to E_vacuum.out"},
+        {"name": "--log", "type": str, "default": None, "help": "Path to SCF running log"},
+        {"name": "--fermi", "type": float, "default": None, "help": "Override E_Fermi (eV)"},
+        {"name": "--period", "type": float, "default": None, "help": "Averaging period in Å"},
+        {"name": "--no-plot", "action": "store_true", "help": "Write data without a PNG plot"},
+    ],
+)
+def task_macro_avg_potential(
+    args: list[str] | None = None,
+    interactive: bool = True,
+    parsed_args=None,
+    output_dir: str = ".",
+) -> dict[str, Any] | None:
+    """Compute the periodic double-window macroscopic potential (task 1102)."""
     console = _get_console()
+    root = Path.cwd()
+    pot_path = _pick_path(parsed_args, args, "file", ("POT", "ELEC", "LOCPOT")) or _find_potential_file(root)
+    if pot_path is None:
+        console.print("[red]No electrostatic potential cube file found.[/red]")
+        return None
+    profile = _read_profile(pot_path)
+    if profile is None:
+        console.print("[red]Could not read potential cube file.[/red]")
+        return None
+    z_ang, planar, dz, shape = profile
+    fermi, log_path = _resolve_fermi(root, pot_path, parsed_args, args)
+    if fermi is None:
+        console.print("[red]Could not find E_Fermi in an SCF log.[/red]")
+        console.print("[dim]Pass --log running_scf.log or --fermi <eV>.[/dim]")
+        return None
+
+    cell_length = dz * shape[2]
+    period = getattr(parsed_args, "period", None) if parsed_args is not None else None
+    if period is None and interactive:
+        from rich.prompt import Prompt
+        period = float(Prompt.ask("  Averaging period (Å) — typically inter-layer spacing",
+                                  default=f"{cell_length / 4:.2f}"))
+    period = float(period if period is not None else cell_length / 4)
+    if period <= 0.0:
+        raise ValueError("Averaging period must be positive")
+    window_points = max(1, int(round(period / dz)))
+    macro = macroscopic_average(planar, window_points)
+
+    vacuum_path = _find_vacuum_file(
+        root, pot_path, getattr(parsed_args, "vacuum_file", None) if parsed_args else None
+    )
+    vacuum_level = read_vacuum_level(vacuum_path) if vacuum_path else None
+    if vacuum_level is None:
+        wf = extract_work_function(macro, z_ang, e_fermi=fermi, vacuum_fraction=0.3)
+        wf["vacuum_source"] = "top 30% macroscopic-average fallback"
+    else:
+        wf = {"vacuum_level": vacuum_level, "work_function": vacuum_level - fermi,
+              "e_fermi": fermi, "vacuum_source": str(vacuum_path)}
 
     console.print()
     console.print("[bold cyan]=== Macroscopic-Averaged Potential ===[/bold cyan]")
-    console.print()
-
-    pot_path = None
-    if args:
-        for arg in args:
-            if "POT" in arg.upper() or "ELEC" in arg.upper():
-                p = Path(arg)
-                if p.exists():
-                    pot_path = p
-                    break
-    if pot_path is None:
-        pot_path = _find_potential_file()
-
-    if pot_path is None:
-        console.print("[red]No electrostatic potential file found.[/red]")
-        return
-
-    result = read_potential_cube(pot_path)
-    if result is None:
-        console.print("[red]Could not read potential file.[/red]")
-        return
-
-    potential_3d, cell, origin = result
-    nz = potential_3d.shape[0]
-
-    from abacuscopilot.core.constants import BOHR_TO_ANGSTROM
-    cell_ang = cell * BOHR_TO_ANGSTROM
-    c_len = np.linalg.norm(cell_ang[2])
-
-    # 1D planar average
-    avg_pot = np.mean(potential_3d, axis=(1, 2))
-    z_coords = origin[2] + np.linspace(0, cell[2, 2], nz, endpoint=False)
-    z_ang = z_coords * BOHR_TO_ANGSTROM
-    dz = c_len / nz
-
-    # Ask for period
-    if interactive:
-        from rich.prompt import Prompt
-        period_str = Prompt.ask("  Averaging period (Å) — typically inter-layer spacing", default=f"{c_len/4:.2f}")
-        period = float(period_str)
-    else:
-        period = c_len / 4  # rough estimate
-
-    n_period = max(1, int(period / dz))
-
-    # Double running average (macroscopic average)
-    def running_avg(arr: np.ndarray, n: int) -> np.ndarray:
-        return np.convolve(arr, np.ones(n) / n, mode="same")
-
-    macro_pot = running_avg(running_avg(avg_pot, n_period), n_period)
-
-    # Extract work function
-    e_fermi = 0.0
-    wf = extract_work_function(macro_pot, z_ang, e_fermi=e_fermi, vacuum_fraction=0.3)
-
-    console.print()
+    console.print(f"  [bold]Grid:[/bold] {shape[0]} × {shape[1]} × {shape[2]}")
+    console.print(f"  [bold]Averaging period:[/bold] {period:.4f} Å ({window_points} points)")
+    console.print(f"  [bold]E_Fermi:[/bold] {fermi:.6f} eV")
     console.print(f"  [bold green]Vacuum Level:[/bold green] {wf['vacuum_level']:.4f} eV")
     console.print(f"  [bold green]Work Function (Φ):[/bold green] {wf['work_function']:.4f} eV")
+    if log_path:
+        console.print(f"  [dim]SCF log: {log_path}[/dim]")
 
-    # Plot
-    import matplotlib.pyplot as plt
-
-    from abacuscopilot.plotting.style import load_style_from_config
-    load_style_from_config()
-
-    fig, ax = plt.subplots(figsize=(8, 5))
-    ax.plot(z_ang, avg_pot, color="#1f77b4", linewidth=0.8, alpha=0.5, label="Planar average")
-    ax.plot(z_ang, macro_pot, color="#d62728", linewidth=1.8, label="Macroscopic average")
-    ax.axhline(y=wf["vacuum_level"], color="red", linestyle="--", linewidth=0.8)
-    ax.set_xlabel("z (Å)")
-    ax.set_ylabel("V (eV)")
-    ax.set_title(f"Macroscopic-Averaged Potential — Φ = {wf['work_function']:.3f} eV")
-    ax.legend(loc="upper right")
-
-    save_name = "macro_avg_potential.png"
-    fig.savefig(save_name)
-    console.print(f"  [green]✓ Plot saved to {save_name}[/green]")
-    plt.close(fig)
-    console.print()
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    np.savetxt(output / "macro_avg_potential.dat", np.column_stack([z_ang, macro]),
+               fmt="%.8f", header="z_Angstrom  V_eV")
+    wf.update({"period_angstrom": period, "window_points": window_points})
+    if not getattr(parsed_args, "no_plot", False):
+        _plot_work_function(
+            output / "macro_avg_potential.png", z_ang, planar, fermi, wf["vacuum_level"],
+            f"Macroscopic-Averaged Potential — Φ = {wf['work_function']:.3f} eV", macro=macro,
+        )
+    _write_work_function_result(output, wf)
+    console.print(f"  [dim]Results saved to {output / 'work_function.json'}[/dim]")
+    return wf

--- a/abacuscopilot/postprocessing/workfunc_tasks.py
+++ b/abacuscopilot/postprocessing/workfunc_tasks.py
@@ -51,45 +51,12 @@ def _find_potential_file(root: str | Path = ".") -> Path | None:
     return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
-def _find_vacuum_file(
-    root: str | Path = ".",
-    potential_path: str | Path | None = None,
-    explicit: str | Path | None = None,
-) -> Path | None:
-    """Find zstar/ABACUS's scalar vacuum-level report.
-
-    ``E_vacuum.out`` is preferred over the two-sided diagnostic because it is
-    already a single vacuum reference suitable for ``Phi = V_vacuum - E_F``.
-    """
-    if explicit:
-        path = Path(explicit)
-        return path if path.is_file() else None
-
-    root = Path(root)
-    search_roots = []
-    if potential_path is not None:
-        potential = Path(potential_path)
-        search_roots.extend([potential.parent, potential.parent.parent])
-    search_roots.extend([root, *[p for p in root.glob("OUT.*") if p.is_dir()]])
-
-    seen: set[Path] = set()
-    for directory in search_roots:
-        directory = directory.resolve()
-        if directory in seen:
-            continue
-        seen.add(directory)
-        for name in ("E_vacuum.out", "E_vacuum_sides.out"):
-            path = directory / name
-            if path.is_file():
-                return path
-    return None
-
-
 def read_vacuum_level(filepath: str | Path) -> float | None:
-    """Read a vacuum level in eV from ``E_vacuum.out``-style text.
+    """Read a vacuum level in eV from a precomputed text override.
 
-    zstar writes ``E_VACUUM (eV) = ...``.  The parser also accepts a
-    two-sided report and returns the mean of its lower/upper plateau values.
+    The parser accepts ``E_VACUUM (eV) = ...`` and two-sided reports.  This is
+    only an explicit compatibility override; normal tasks derive the level
+    directly from the raw cube.
     """
     path = Path(filepath)
     if not path.is_file():
@@ -178,11 +145,10 @@ def read_fermi_energy(filepath: str | Path) -> float | None:
 # =============================================================================
 
 
-def read_potential_cube(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
-    """Read electrostatic potential from a Cube-format file.
-
-    Returns (data_3d, cell_bohr, origin) or None on failure.
-    """
+def _read_potential_cube_details(
+    filepath: str | Path,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None:
+    """Read cube data plus atom coordinates needed for vacuum detection."""
     filepath = Path(filepath)
     if not filepath.exists():
         return None
@@ -223,6 +189,15 @@ def read_potential_cube(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, n
     if data_start >= len(lines):
         return None
 
+    atom_positions = []
+    for line in lines[geometry_index + 4:data_start]:
+        parts = line.split()
+        if len(parts) >= 5:
+            try:
+                atom_positions.append([float(parts[2]), float(parts[3]), float(parts[4])])
+            except ValueError:
+                return None
+
     raw = []
     for line in lines[data_start:]:
         raw.extend(float(x) for x in line.split())
@@ -235,6 +210,21 @@ def read_potential_cube(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, n
     # Gaussian/ABACUS cube data are ordered with the last grid axis varying
     # fastest.  Keeping (x, y, z) here makes the z planar average unambiguous.
     data = np.asarray(raw[:expected], dtype=float).reshape(nx, ny, nz)
+    atoms = np.asarray(atom_positions, dtype=float).reshape((-1, 3))
+    return data, cell, origin, atoms
+
+
+def read_potential_cube(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """Read electrostatic potential from a Cube-format file.
+
+    Returns ``(data_3d, cell_bohr, origin)`` for compatibility with the
+    original helper.  Task 1101/1102 additionally use the internal reader's
+    atom coordinates to locate the vacuum gap directly from the raw cube.
+    """
+    result = _read_potential_cube_details(filepath)
+    if result is None:
+        return None
+    data, cell, origin, _atoms = result
     return data, cell, origin
 
 
@@ -291,6 +281,68 @@ def extract_work_function(
     }
 
 
+def _largest_periodic_gap(atom_coordinates: np.ndarray, cell_length: float) -> tuple[float, float, float] | None:
+    """Return the largest atom-free interval on a periodic one-dimensional cell."""
+    if cell_length <= 0.0 or atom_coordinates.size == 0:
+        return None
+    atoms = np.sort(np.mod(np.asarray(atom_coordinates, dtype=float), cell_length))
+    gaps = np.diff(np.append(atoms, atoms[0] + cell_length))
+    index = int(np.argmax(gaps))
+    start = float(atoms[index])
+    end = float(atoms[(index + 1) % atoms.size])
+    if index == atoms.size - 1:
+        end += cell_length
+    return start, end, float(gaps[index])
+
+
+def estimate_vacuum_level_from_cube(
+    potential_1d: np.ndarray,
+    z_axis: np.ndarray,
+    atom_z: np.ndarray,
+    cell_length: float,
+    *,
+    exclude_distance: float = 3.0,
+) -> dict[str, Any] | None:
+    """Estimate ``V_vacuum`` directly from a planar-averaged ABACUS cube.
+
+    The largest periodic atom-free gap is treated as vacuum.  Surface-adjacent
+    regions are excluded on both sides before averaging the remaining plateau,
+    which avoids assuming that the vacuum is always the last 30% of the cell.
+    """
+    potential_1d = np.asarray(potential_1d, dtype=float)
+    z_axis = np.asarray(z_axis, dtype=float)
+    gap = _largest_periodic_gap(atom_z, cell_length)
+    if gap is None:
+        return None
+    gap_start, gap_end, gap_length = gap
+    trim = max(0.0, float(exclude_distance))
+    if gap_length <= 2.0 * trim:
+        trim = 0.25 * gap_length
+    start, end = gap_start + trim, gap_end - trim
+    if end <= start:
+        return None
+
+    wrapped_z = np.mod(z_axis, cell_length)
+    if end <= cell_length:
+        mask = (wrapped_z >= start) & (wrapped_z <= end)
+    else:
+        mask = (wrapped_z >= start) | (wrapped_z <= end - cell_length)
+    indices = np.where(mask)[0]
+    if indices.size == 0:
+        return None
+    values = potential_1d[indices]
+    return {
+        "vacuum_level": float(np.mean(values)),
+        "vacuum_std": float(np.std(values)),
+        "vacuum_points": int(indices.size),
+        "vacuum_coordinate": float(np.mod(0.5 * (start + end), cell_length)),
+        "vacuum_gap_start": float(np.mod(gap_start, cell_length)),
+        "vacuum_gap_end": float(np.mod(gap_end, cell_length)),
+        "vacuum_gap_length": gap_length,
+        "vacuum_exclude": trim,
+    }
+
+
 def macroscopic_average(potential_1d: np.ndarray, window_points: int) -> np.ndarray:
     """Apply the periodic double-window macroscopic average used by 1102.
 
@@ -337,19 +389,27 @@ def _pick_path(parsed_args, args: list[str] | None, name: str, keywords: tuple[s
     return None
 
 
-def _read_profile(path: Path) -> tuple[np.ndarray, np.ndarray, float, tuple[int, int, int]] | None:
-    """Read a cube and return ``(z, planar_potential, dz, shape)`` in eV/Å."""
-    result = read_potential_cube(path)
+def _read_profile(
+    path: Path,
+) -> tuple[np.ndarray, np.ndarray, float, tuple[int, int, int], np.ndarray, float] | None:
+    """Read a cube and return profile, atom z-coordinates, and cell length."""
+    result = _read_potential_cube_details(path)
     if result is None:
         return None
-    potential, cell, origin = result
+    potential, cell, origin, atoms = result
     nx, ny, nz = potential.shape
     cell_ang = cell * BOHR_TO_ANGSTROM
     c_length = float(np.linalg.norm(cell_ang[2]))
-    z = (origin[2] + np.linspace(0.0, cell[2, 2], nz, endpoint=False)) * BOHR_TO_ANGSTROM
+    z = np.arange(nz, dtype=float) * c_length / nz
     dz = c_length / nz
     profile = _potential_to_ev(np.mean(potential, axis=(0, 1)), path)
-    return z, profile, dz, (nx, ny, nz)
+    if atoms.size:
+        c_vector = cell[2]
+        c_norm = float(np.linalg.norm(c_vector))
+        atom_z = np.dot(atoms - origin, c_vector / c_norm) * BOHR_TO_ANGSTROM
+    else:
+        atom_z = np.empty(0, dtype=float)
+    return z, profile, dz, (nx, ny, nz), atom_z, c_length
 
 
 def _resolve_fermi(
@@ -412,7 +472,8 @@ def _plot_work_function(
     description="Compute work function from V_vacuum and the final SCF E_Fermi",
     cli_args=[
         {"name": "--file", "type": str, "default": None, "help": "Path to electrostatic potential cube file"},
-        {"name": "--vacuum-file", "type": str, "default": None, "help": "Path to E_vacuum.out"},
+        {"name": "--vacuum-file", "type": str, "default": None, "help": "Optional precomputed vacuum-level override"},
+        {"name": "--vacuum-exclude", "type": float, "default": 3.0, "help": "Distance (Å) excluded next to slab atoms"},
         {"name": "--log", "type": str, "default": None, "help": "Path to SCF running log"},
         {"name": "--fermi", "type": float, "default": None, "help": "Override E_Fermi (eV)"},
         {"name": "--no-plot", "action": "store_true", "help": "Write data without a PNG plot"},
@@ -426,18 +487,15 @@ def task_work_function(
 ) -> dict[str, Any] | None:
     """Compute ``Phi = V_vacuum - E_Fermi`` for an ABACUS slab.
 
-    When zstar has already produced ``E_vacuum.out``, that scalar is used
-    directly.  The cube is only needed for the optional planar profile/plot;
-    if the report is absent, the final vacuum fraction is retained as a
-    clearly marked fallback estimate.
+    The vacuum level is derived from the largest atom-free periodic gap in the
+    raw cube.  ``--vacuum-file`` is retained only as an explicit override for
+    users who already have an independently validated scalar reference.
     """
     console = _get_console()
     root = Path.cwd()
     output = Path(output_dir)
     pot_path = _pick_path(parsed_args, args, "file", ("POT", "ELEC", "LOCPOT")) or _find_potential_file(root)
-    vacuum_path = _find_vacuum_file(
-        root, pot_path, getattr(parsed_args, "vacuum_file", None) if parsed_args else None
-    )
+    vacuum_path = Path(parsed_args.vacuum_file) if parsed_args and parsed_args.vacuum_file else None
     fermi, log_path = _resolve_fermi(root, pot_path, parsed_args, args)
 
     console.print()
@@ -455,22 +513,32 @@ def task_work_function(
     if pot_path:
         console.print(f"  [dim]Potential file: {pot_path}[/dim]")
     if profile:
-        z_ang, planar, _dz, shape = profile
+        z_ang, planar, _dz, shape, atom_z, cell_length = profile
         console.print(f"  [bold]Grid:[/bold] {shape[0]} × {shape[1]} × {shape[2]}")
     else:
-        z_ang = planar = None
+        z_ang = planar = atom_z = cell_length = None
 
+    vacuum_info = (
+        estimate_vacuum_level_from_cube(
+            planar, z_ang, atom_z, cell_length,
+            exclude_distance=getattr(parsed_args, "vacuum_exclude", 3.0),
+        )
+        if profile and atom_z.size else None
+    )
     vacuum_level = read_vacuum_level(vacuum_path) if vacuum_path else None
-    if vacuum_level is not None:
+    if vacuum_info is not None:
+        wf = {**vacuum_info, "work_function": vacuum_info["vacuum_level"] - fermi,
+              "e_fermi": fermi, "vacuum_source": "largest atom-free gap in cube"}
+    elif vacuum_level is not None:
         source = str(vacuum_path)
         wf = {"vacuum_level": vacuum_level, "work_function": vacuum_level - fermi,
               "e_fermi": fermi, "vacuum_source": source}
     elif profile:
         fallback = extract_work_function(planar, z_ang, e_fermi=fermi, vacuum_fraction=0.3)
         wf = {**fallback, "vacuum_source": "top 30% planar-average fallback"}
-        console.print("  [yellow]E_vacuum.out not found; using top 30% planar average.[/yellow]")
+        console.print("  [yellow]Atom coordinates were unavailable; using top 30% planar average.[/yellow]")
     else:
-        console.print("[red]No readable potential cube or E_vacuum.out found.[/red]")
+        console.print("[red]No readable electrostatic-potential cube found.[/red]")
         return None
 
     console.print(f"  [bold green]Vacuum Level:[/bold green] {wf['vacuum_level']:.4f} eV")
@@ -499,7 +567,8 @@ def task_work_function(
     description="Compute a periodic double-averaged potential and work function",
     cli_args=[
         {"name": "--file", "type": str, "default": None, "help": "Path to electrostatic potential cube file"},
-        {"name": "--vacuum-file", "type": str, "default": None, "help": "Path to E_vacuum.out"},
+        {"name": "--vacuum-file", "type": str, "default": None, "help": "Optional precomputed vacuum-level override"},
+        {"name": "--vacuum-exclude", "type": float, "default": 3.0, "help": "Distance (Å) excluded next to slab atoms"},
         {"name": "--log", "type": str, "default": None, "help": "Path to SCF running log"},
         {"name": "--fermi", "type": float, "default": None, "help": "Override E_Fermi (eV)"},
         {"name": "--period", "type": float, "default": None, "help": "Averaging period in Å"},
@@ -523,14 +592,13 @@ def task_macro_avg_potential(
     if profile is None:
         console.print("[red]Could not read potential cube file.[/red]")
         return None
-    z_ang, planar, dz, shape = profile
+    z_ang, planar, dz, shape, atom_z, cell_length = profile
     fermi, log_path = _resolve_fermi(root, pot_path, parsed_args, args)
     if fermi is None:
         console.print("[red]Could not find E_Fermi in an SCF log.[/red]")
         console.print("[dim]Pass --log running_scf.log or --fermi <eV>.[/dim]")
         return None
 
-    cell_length = dz * shape[2]
     period = getattr(parsed_args, "period", None) if parsed_args is not None else None
     if period is None and interactive:
         from rich.prompt import Prompt
@@ -542,13 +610,21 @@ def task_macro_avg_potential(
     window_points = max(1, int(round(period / dz)))
     macro = macroscopic_average(planar, window_points)
 
-    vacuum_path = _find_vacuum_file(
-        root, pot_path, getattr(parsed_args, "vacuum_file", None) if parsed_args else None
+    vacuum_path = Path(parsed_args.vacuum_file) if parsed_args and parsed_args.vacuum_file else None
+    vacuum_info = (
+        estimate_vacuum_level_from_cube(
+            macro, z_ang, atom_z, cell_length,
+            exclude_distance=getattr(parsed_args, "vacuum_exclude", 3.0),
+        )
+        if atom_z.size else None
     )
     vacuum_level = read_vacuum_level(vacuum_path) if vacuum_path else None
-    if vacuum_level is None:
+    if vacuum_info is not None:
+        wf = {**vacuum_info, "work_function": vacuum_info["vacuum_level"] - fermi,
+              "e_fermi": fermi, "vacuum_source": "largest atom-free gap in macro profile"}
+    elif vacuum_level is None:
         wf = extract_work_function(macro, z_ang, e_fermi=fermi, vacuum_fraction=0.3)
-        wf["vacuum_source"] = "top 30% macroscopic-average fallback"
+        wf["vacuum_source"] = "top 30% macroscopic-average fallback (no atom coordinates)"
     else:
         wf = {"vacuum_level": vacuum_level, "work_function": vacuum_level - fermi,
               "e_fermi": fermi, "vacuum_source": str(vacuum_path)}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,14 +194,11 @@ class TestTaskDiscovery:
             "Band Structure", "Batch", "Charge Density", "DOS/PDOS",
             "INPUT", "KPT", "Mechanics", "Population",
             "SCF Analysis", "STRU", "Structure Editing", "Symmetry",
-            "System",
+            "System", "Work Function",
         ]
         for cat in expected:
             assert cat in categories, f"Category '{cat}' not found"
-        # "Work Function" is a coming-soon module (tasks 1101/1102 hidden
-        # until their functionality is verified) — it must NOT be a registered
-        # category yet, but the interactive menu still lists it as such.
-        assert "Work Function" not in categories
+        assert "Work Function" in categories
 
     def test_task_count(self):
         """At least 40 tasks are registered."""
@@ -226,6 +223,8 @@ class TestTaskDiscovery:
             1201: "Elastic Constants",
             601: "PBS Script",
             602: "SLURM Script",
+            1101: "Work Function",
+            1102: "Macroscopic Avg",
         }
         for tid, name in key_tasks.items():
             t = registry.get_task(tid)

--- a/tests/test_workfunc_real_case.py
+++ b/tests/test_workfunc_real_case.py
@@ -1,0 +1,59 @@
+"""Optional end-to-end check against a completed ABACUS SCF case.
+
+Set ``ABACUS_WORKFUNC_CASE`` to a case directory containing
+``OUT.ABACUS/ElecStaticPot.cube`` and ``OUT.ABACUS/running_scf.log`` before
+running this file.  The large calculation output is intentionally not stored
+in the source repository.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from abacuscopilot.postprocessing.workfunc_tasks import (
+    _read_profile,
+    estimate_vacuum_level_from_cube,
+    macroscopic_average,
+    read_fermi_energy,
+)
+
+
+def _real_case_paths() -> tuple[Path, Path]:
+    root = os.environ.get("ABACUS_WORKFUNC_CASE")
+    if not root:
+        pytest.skip("Set ABACUS_WORKFUNC_CASE to run the real ABACUS integration test")
+    case = Path(root)
+    cube = case / "OUT.ABACUS" / "ElecStaticPot.cube"
+    log = case / "OUT.ABACUS" / "running_scf.log"
+    if not cube.is_file() or not log.is_file():
+        pytest.skip("ABACUS_WORKFUNC_CASE lacks ElecStaticPot.cube or running_scf.log")
+    return cube, log
+
+
+def test_completed_abacus_scf_supports_raw_cube_workfunc_pipeline():
+    cube, log = _real_case_paths()
+    profile = _read_profile(cube)
+    assert profile is not None
+    z_ang, planar, dz, shape, atom_z, cell_length = profile
+    fermi = read_fermi_energy(log)
+    assert fermi is not None
+    assert shape[2] > 1 and atom_z.size > 0
+
+    raw_vacuum = estimate_vacuum_level_from_cube(
+        planar, z_ang, atom_z, cell_length, exclude_distance=3.0
+    )
+    assert raw_vacuum is not None
+    assert np.isfinite(raw_vacuum["vacuum_level"])
+    assert np.isfinite(raw_vacuum["vacuum_level"] - fermi)
+
+    window = max(1, int(round(3.0 / dz)))
+    macro = macroscopic_average(planar, window)
+    macro_vacuum = estimate_vacuum_level_from_cube(
+        macro, z_ang, atom_z, cell_length, exclude_distance=3.0
+    )
+    assert macro_vacuum is not None
+    assert np.isfinite(macro_vacuum["vacuum_level"] - fermi)

--- a/tests/test_workfunc_tasks.py
+++ b/tests/test_workfunc_tasks.py
@@ -18,19 +18,20 @@ from abacuscopilot.postprocessing.workfunc_tasks import (
 )
 
 
-def _write_cube(path, profile_ry: np.ndarray) -> None:
+def _write_cube(path, profile_ry: np.ndarray, atom_z: list[float] | None = None) -> None:
     """Write a small x/y/z cube with a known z profile in Rydberg."""
     nx, ny, nz = 2, 2, len(profile_ry)
+    atom_z = [0.0] if atom_z is None else atom_z
     values = np.broadcast_to(profile_ry, (nx, ny, nz)).ravel()
     rows = [
         "ABACUS electrostatic potential",
         "synthetic test cube",
-        "1 0.0 0.0 0.0",
+        f"{len(atom_z)} 0.0 0.0 0.0",
         f"{nx} 1.0 0.0 0.0",
         f"{ny} 0.0 1.0 0.0",
-        f"{nz} 0.0 0.0 1.0",
-        "1 1.0 0.0 0.0 0.0",
+        f"{nz} 0.0 0.0 {32.0 / nz:.10f}",
     ]
+    rows.extend(f"1 1.0 0.0 0.0 {z:.10f}" for z in atom_z)
     rows.extend(" ".join(f"{value:.10f}" for value in values[i:i + 6])
                 for i in range(0, len(values), 6))
     path.write_text("\n".join(rows) + "\n", encoding="utf-8")
@@ -46,7 +47,7 @@ def test_cube_reader_preserves_z_axis_and_units(tmp_path):
     data, cell, origin = result
     assert data.shape == (2, 2, 8)
     assert np.allclose(data.mean(axis=(0, 1)), profile)
-    assert np.allclose(cell[2], [0.0, 0.0, 8.0])
+    assert np.allclose(cell[2], [0.0, 0.0, 32.0])
     assert np.allclose(origin, [0.0, 0.0, 0.0])
 
 
@@ -62,8 +63,13 @@ def test_vacuum_and_fermi_parsers_use_final_electronic_values(tmp_path):
     assert read_fermi_energy(log) == 2.7211386259
 
 
-def test_work_function_uses_e_vacuum_and_scf_fermi_without_cube(tmp_path, monkeypatch):
-    (tmp_path / "E_vacuum.out").write_text("E_VACUUM (eV) = 5.75\n")
+def test_work_function_derives_vacuum_from_raw_cube_and_scf_fermi(tmp_path, monkeypatch):
+    profile = np.full(32, 0.1)
+    # The periodic gap from z=10 to z=32→0→5 Bohr is the vacuum plateau.
+    profile[5:32] = 0.6
+    profile[:6] = 0.6
+    cube = tmp_path / "ElecStaticPot.cube"
+    _write_cube(cube, profile, atom_z=[5.0, 10.0])
     (tmp_path / "running_scf.log").write_text("E_Fermi 0.2000000000 2.7211386259\n")
     monkeypatch.chdir(tmp_path)
 
@@ -71,15 +77,16 @@ def test_work_function_uses_e_vacuum_and_scf_fermi_without_cube(tmp_path, monkey
         args=[],
         interactive=False,
         parsed_args=SimpleNamespace(
-            file=None, vacuum_file=None, log=None, fermi=None, no_plot=True
+            file=str(cube), vacuum_file=None, vacuum_exclude=3.0,
+            log=None, fermi=None, no_plot=True
         ),
         output_dir=str(tmp_path / "out"),
     )
     assert result is not None
-    assert result["vacuum_level"] == 5.75
-    assert np.isclose(result["work_function"], 5.75 - 2.7211386259)
+    assert np.isclose(result["vacuum_level"], 0.6 * RY_TO_EV, atol=0.05)
+    assert np.isclose(result["work_function"], 0.6 * RY_TO_EV - 2.7211386259, atol=0.05)
     saved = json.loads((tmp_path / "out" / "work_function.json").read_text())
-    assert saved["vacuum_source"].endswith("E_vacuum.out")
+    assert saved["vacuum_source"] == "largest atom-free gap in cube"
 
 
 def test_macroscopic_average_is_periodic_and_double_filtered():
@@ -91,24 +98,25 @@ def test_macroscopic_average_is_periodic_and_double_filtered():
 
 
 def test_macro_task_converts_ry_and_uses_vacuum_and_fermi(tmp_path, monkeypatch):
-    profile = np.r_[np.linspace(0.0, 0.2, 8), np.full(8, 0.5)]
+    profile = np.full(32, 0.1)
+    profile[5:32] = 0.6
+    profile[:6] = 0.6
     cube = tmp_path / "ElecStaticPot.cube"
-    _write_cube(cube, profile)
-    (tmp_path / "E_vacuum.out").write_text("E_VACUUM (eV) = 7.0\n")
     (tmp_path / "running_scf.log").write_text("E_Fermi 0.1000000000 1.3605693123\n")
+    _write_cube(cube, profile, atom_z=[5.0, 10.0])
     monkeypatch.chdir(tmp_path)
 
     result = task_macro_avg_potential(
         args=[],
         interactive=False,
         parsed_args=SimpleNamespace(
-            file=str(cube), vacuum_file=None, log=None, fermi=None,
+            file=str(cube), vacuum_file=None, vacuum_exclude=3.0, log=None, fermi=None,
             period=2.0, no_plot=True,
         ),
         output_dir=str(tmp_path / "out"),
     )
     assert result is not None
-    assert result["vacuum_level"] == 7.0
-    assert np.isclose(result["work_function"], 7.0 - 1.3605693123)
+    assert np.isclose(result["vacuum_level"], 0.6 * RY_TO_EV, atol=0.2)
+    assert np.isclose(result["work_function"], 0.6 * RY_TO_EV - 1.3605693123, atol=0.2)
     macro = np.loadtxt(tmp_path / "out" / "macro_avg_potential.dat")[:, 1]
     assert np.isclose(macro.max(), (profile * RY_TO_EV).max(), atol=1.0)

--- a/tests/test_workfunc_tasks.py
+++ b/tests/test_workfunc_tasks.py
@@ -1,0 +1,114 @@
+"""Regression tests for ABACUS work-function tasks 1101 and 1102."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+
+from abacuscopilot.core.constants import RY_TO_EV
+from abacuscopilot.postprocessing.workfunc_tasks import (
+    macroscopic_average,
+    read_fermi_energy,
+    read_potential_cube,
+    read_vacuum_level,
+    task_macro_avg_potential,
+    task_work_function,
+)
+
+
+def _write_cube(path, profile_ry: np.ndarray) -> None:
+    """Write a small x/y/z cube with a known z profile in Rydberg."""
+    nx, ny, nz = 2, 2, len(profile_ry)
+    values = np.broadcast_to(profile_ry, (nx, ny, nz)).ravel()
+    rows = [
+        "ABACUS electrostatic potential",
+        "synthetic test cube",
+        "1 0.0 0.0 0.0",
+        f"{nx} 1.0 0.0 0.0",
+        f"{ny} 0.0 1.0 0.0",
+        f"{nz} 0.0 0.0 1.0",
+        "1 1.0 0.0 0.0 0.0",
+    ]
+    rows.extend(" ".join(f"{value:.10f}" for value in values[i:i + 6])
+                for i in range(0, len(values), 6))
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def test_cube_reader_preserves_z_axis_and_units(tmp_path):
+    profile = np.linspace(1.0, 2.0, 8)
+    cube = tmp_path / "ElecStaticPot.cube"
+    _write_cube(cube, profile)
+
+    result = read_potential_cube(cube)
+    assert result is not None
+    data, cell, origin = result
+    assert data.shape == (2, 2, 8)
+    assert np.allclose(data.mean(axis=(0, 1)), profile)
+    assert np.allclose(cell[2], [0.0, 0.0, 8.0])
+    assert np.allclose(origin, [0.0, 0.0, 0.0])
+
+
+def test_vacuum_and_fermi_parsers_use_final_electronic_values(tmp_path):
+    vacuum = tmp_path / "E_vacuum.out"
+    vacuum.write_text("E_VACUUM (eV) = 5.75000000000 at z (Angstrom) = 10.0\n")
+    log = tmp_path / "running_scf.log"
+    log.write_text(
+        "E_Fermi        0.1000000000        1.3605693123\n"
+        "E_Fermi        0.2000000000 Ry     2.7211386259 eV\n"
+    )
+    assert read_vacuum_level(vacuum) == 5.75
+    assert read_fermi_energy(log) == 2.7211386259
+
+
+def test_work_function_uses_e_vacuum_and_scf_fermi_without_cube(tmp_path, monkeypatch):
+    (tmp_path / "E_vacuum.out").write_text("E_VACUUM (eV) = 5.75\n")
+    (tmp_path / "running_scf.log").write_text("E_Fermi 0.2000000000 2.7211386259\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = task_work_function(
+        args=[],
+        interactive=False,
+        parsed_args=SimpleNamespace(
+            file=None, vacuum_file=None, log=None, fermi=None, no_plot=True
+        ),
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result is not None
+    assert result["vacuum_level"] == 5.75
+    assert np.isclose(result["work_function"], 5.75 - 2.7211386259)
+    saved = json.loads((tmp_path / "out" / "work_function.json").read_text())
+    assert saved["vacuum_source"].endswith("E_vacuum.out")
+
+
+def test_macroscopic_average_is_periodic_and_double_filtered():
+    values = np.sin(np.linspace(0.0, 2.0 * np.pi, 32, endpoint=False)) + 3.0
+    result = macroscopic_average(values, 5)
+    assert result.shape == values.shape
+    assert np.isclose(result.mean(), values.mean())
+    assert np.max(np.abs(result - 3.0)) < np.max(np.abs(values - 3.0))
+
+
+def test_macro_task_converts_ry_and_uses_vacuum_and_fermi(tmp_path, monkeypatch):
+    profile = np.r_[np.linspace(0.0, 0.2, 8), np.full(8, 0.5)]
+    cube = tmp_path / "ElecStaticPot.cube"
+    _write_cube(cube, profile)
+    (tmp_path / "E_vacuum.out").write_text("E_VACUUM (eV) = 7.0\n")
+    (tmp_path / "running_scf.log").write_text("E_Fermi 0.1000000000 1.3605693123\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = task_macro_avg_potential(
+        args=[],
+        interactive=False,
+        parsed_args=SimpleNamespace(
+            file=str(cube), vacuum_file=None, log=None, fermi=None,
+            period=2.0, no_plot=True,
+        ),
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result is not None
+    assert result["vacuum_level"] == 7.0
+    assert np.isclose(result["work_function"], 7.0 - 1.3605693123)
+    macro = np.loadtxt(tmp_path / "out" / "macro_avg_potential.dat")[:, 1]
+    assert np.isclose(macro.max(), (profile * RY_TO_EV).max(), atol=1.0)


### PR DESCRIPTION
## Summary

Implement and enable work-function analysis tasks 1101 and 1102.

The implementation is fully independent of zstar-generated files (ZStar is a tookit about polarization calculations developed by me https://github.com/xdzhu/ZStar). It operates directly on ABACUS SCF outputs, especially:

- `OUT.ABACUS/ElecStaticPot.cube`
- `OUT.ABACUS/running_scf.log`

## Implemented Features

### Task 1101 — Work Function

- Parse the ABACUS electrostatic-potential cube file.
- Read atom coordinates and lattice vectors from the cube header.
- Detect the largest periodic atom-free gap as the vacuum region.
- Exclude surface-adjacent regions before averaging the vacuum plateau.
- Obtain the final `E_Fermi` from the SCF log.
- Compute:

  ```text
  Phi = V_vacuum - E_Fermi
  ```

- Correctly convert ABACUS electrostatic potential values from Ry to eV.
- Support explicit CLI overrides for the cube file, SCF log, Fermi energy, and vacuum exclusion distance.

### Task 1102 — Macroscopic Average

- Compute the planar-averaged potential along the vacuum direction.
- Apply a periodic double-window macroscopic average.
- Avoid the artificial edge effects caused by zero-padding convolution.
- Derive the vacuum level directly from the smoothed potential and cube atom coordinates.
- Compute the corresponding work function using the SCF Fermi energy.
- Support a user-defined averaging period.

## Additional Changes

- Improved ABACUS cube parsing, including:
  - ABACUS cube header format
  - Atom coordinates
  - Grid dimensions
  - Periodic cell vectors
  - Correct grid ordering
- Improved Fermi-energy parsing for common ABACUS formats.
- Added JSON and profile outputs for work-function analysis.
- Updated README and USER_GUIDE documentation.
- Re-enabled tasks 1101 and 1102 in task discovery and the interactive menu.

## Tests

Added unit tests covering:

- Cube parsing and grid ordering
- Atom-coordinate extraction
- Vacuum-gap detection
- Fermi-energy extraction
- Ry-to-eV conversion
- Periodic macroscopic averaging
- Task registration and CLI behavior

Added an optional real-case integration test:

```powershell
$env:ABACUS_WORKFUNC_CASE="D:\path\to\completed_scf"
python -m pytest -q tests/test_workfunc_real_case.py
```

The real-case test uses a completed ABACUS GeS slab SCF with `out_pot 2`, without committing the large cube file to the repository.

Validation results:

```text
6 passed
236 passed, 1 skipped
```

For the completed GeS SCF case:

```text
E_Fermi       = -1.7396927164 eV
V_vacuum      =  2.8208221 eV
Work function =  4.5605148 eV
```

The vacuum level was independently cross-checked against the my `ZStar` `pot` module implementation on the same cube file. 